### PR TITLE
Feat/only create users with group in matchers

### DIFF
--- a/authentication/okta/okta-sync-multi-group/README.md
+++ b/authentication/okta/okta-sync-multi-group/README.md
@@ -8,7 +8,7 @@ This script reads a separate JSON file, [matchers.yml](matchers.yml), which maps
 
 For each Group defined in the YML, an SDM Role will be created, and access to the defined resources will be granted to that Role, using the [filters spec](https://www.strongdm.com/docs/automation/getting-started/filters).
 
-Any user that matches the Okta search filter will be created in SDM (see the "oktaQueryString" definition just below). If they belong to an Okta Group that is defined in the YML, they will be assigned to the corresponding SDM Role. 
+Any user that matches the Okta search filter and has groups associated listed in [matchers.yml](matchers.yml) will be created in SDM, and assigned to the corresponding SDM Role. 
 
 strongDM only supports 1:1 user-role mappings, when there are multiple groups assigned to a okta user, a composite role is created with multiple sub-roles assigned to it.
 
@@ -20,8 +20,6 @@ The script won't remove any Roles or Users in SDM, unless you use the flags: `-d
 
   > For example, the sample file in this folder would create strongDM Roles with access to all `mysql` and `postgres` resources in your organization.
 
-3. Edit the variable `oktaQueryString` in the `GO` file to specify which users to sync to strongDM. (The Okta SDK does not provide a method to retrieve _group members_, unfortunately.)
-
 ## Sample
 ```
 $ go run . -delete-roles-not-in-okta -delete-users-not-in-okta
@@ -30,3 +28,4 @@ $ go run . -delete-roles-not-in-okta -delete-users-not-in-okta
 
 Considerations:
 * For better reporting add `-plan` to your command.
+* When using `-delete-users-not-in-okta​` remember to add your SDM admin emails to Okta, otherwise you could remove the account administrators.

--- a/authentication/okta/okta-sync-multi-group/main.go
+++ b/authentication/okta/okta-sync-multi-group/main.go
@@ -33,7 +33,6 @@ import (
 
 const OKTA_USERS_LIMIT = 500
 
-// modify this Okta query filter with any valid Okta API parameters to control user creation in SDM
 var oktaQueryString = "(status eq \"ACTIVE\")"
 
 var jsonFlag = flag.Bool("json", false, "dump a JSON report for debugging")

--- a/authentication/okta/okta-sync-multi-group/main.go
+++ b/authentication/okta/okta-sync-multi-group/main.go
@@ -31,8 +31,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const OKTA_USERS_LIMIT = 500
+
 // modify this Okta query filter with any valid Okta API parameters to control user creation in SDM
-var oktaQueryString = "profile.login sw \"rodolfo\" and (status eq \"ACTIVE\")"
+var oktaQueryString = "(status eq \"ACTIVE\")"
 
 var jsonFlag = flag.Bool("json", false, "dump a JSON report for debugging")
 var planFlag = flag.Bool("plan", false, "do not apply changes just plan and output the result")
@@ -222,7 +224,7 @@ func loadOktaUsers(ctx context.Context) (oktaUserList, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid Okta configuration")
 	}
-	search := query.NewQueryParams(query.WithSearch(oktaQueryString))
+	search := query.NewQueryParams(query.WithSearch(oktaQueryString), query.WithLimit(OKTA_USERS_LIMIT))
 
 	apiUsers, _, err := client.User.ListUsers(search)
 	if err != nil {
@@ -344,6 +346,7 @@ func matchEntitlements(ctx context.Context, client *sdm.Client, matchers *Matche
 				return nil, err
 			}
 		}
+		result[matcher.Name] = make(entitlementList, 0) // for creating groups without available resources
 		for u := range uniq {
 			result[matcher.Name] = append(result[matcher.Name], u)
 		}
@@ -448,6 +451,10 @@ func syncUsers(ctx context.Context, client *sdm.Client, initialUsers userList, r
 func createMatchingUsers(ctx context.Context, client *sdm.Client, roles roleList, oktaUsers oktaUserList, matchers *MatcherConfig) (userList, error) {
 	matchingUsers := userList{}
 	for _, oktaUser := range oktaUsers {
+		if !oktaUserHasMatchingGroup(oktaUser, matchers) {
+			fmt.Fprintf(os.Stderr, "ignoring user %s - no group in matchers assigned to it\n", oktaUser.Login)
+			continue
+		}
 		user, err := loadOrCreateUser(ctx, client, oktaUser)
 		var alreadyExistsErr *sdm.AlreadyExistsError
 		if errors.As(err, &alreadyExistsErr) {
@@ -493,6 +500,17 @@ func createMatchingUsers(ctx context.Context, client *sdm.Client, roles roleList
 		})
 	}
 	return matchingUsers, nil
+}
+
+func oktaUserHasMatchingGroup(oktaUser oktaUser, matchers *MatcherConfig) bool {
+	for _, oktaGroup := range oktaUser.Groups {
+		for _, matcherGroup := range matchers.Groups {
+			if oktaGroup == matcherGroup.Name {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func loadOrCreateUser(ctx context.Context, client *sdm.Client, oktaUser oktaUser) (*sdm.User, error) {

--- a/authentication/okta/okta-sync-multi-group/matchers.yml
+++ b/authentication/okta/okta-sync-multi-group/matchers.yml
@@ -12,3 +12,7 @@ groups:
     name: rodo-group-engineering
     resources:
       - type:postgres
+  -
+    name: rodo-group-data
+    resources:
+      - type:athena


### PR DESCRIPTION
Changes:
* Create roles for groups with non-existing resources
* Create users only when assigned to a group listed in `matchers.yml`
* Add constant for users retrieval pagination from Okta, current value = 500
* Update docs