### PR TITLE
sdm_health_exporter.py - v0.0.1

### DIFF
--- a/monitoring/sdm_health_exporter/README.md
+++ b/monitoring/sdm_health_exporter/README.md
@@ -1,0 +1,70 @@
+# Purpose
+
+This script serves as an example exporter that can monitor the health of resources ("Infrastructure") and nodes ("Gateways/Relays"). The script uses the following workflow:
+
+1. Make an API call to strongDM's API to retrive information about resources and nodes (configurable by updating `update_interval` variable in `main()`)
+
+2. Collect data about any resource or node that is tagged with the `alert_tag` in strongDM (`alert_tag` variable is configurable in `main()`)
+
+3. Export metrics to a prometheus endpoint as a "Gauge" (0 for healthy, 1 for unhealthy)
+
+*IMPORTANT NOTE*: Currently, the resources and nodes only perform automatic health checks every 12 hours, or when the check is manually initiated through the UI. There is a feature request in place to lower that automatic health check interval, and/or make it possible to initiate a manual check through the API.
+
+
+# Setup
+
+- Create a new strongDM API key
+
+    https://www.strongdm.com/docs/admin-ui-guide/access/api-keys
+
+- Configure the  environment variables:`
+
+    `export SDM_API_ID="<id>"`
+
+    `export SDM_API_SECRET="<secret>"`
+
+- Create a new virtual environment
+
+    `python3 -m venv venv`
+
+- Activate the new environment
+
+    `source venv/bin/activate`
+
+- Install requirements with `pip`
+    
+    `pip install -r requirements.txt`
+
+
+# Sample `/metrics` data
+
+After starting the exporter, the new metrics will be available on `http://<ip or hostname>:8337/metrics`. Here is an example of what the exported metrics will look:
+
+```
+# HELP example_server1 health of resource
+# TYPE example_server1 gauge
+example_server1{id="rs-116<redacted>",name="example_server1",tags="{'lab-infra': '', 'alert': ''}",task="health_check"} 0.0
+# HELP example_server2 health of resource
+# TYPE example_server2 gauge
+example_server2{id="rs-5c6<redacted>",name="example_server2",tags="{'lab-infra': '', 'alert': ''}",task="health_check"} 0.0
+# HELP example_server3 health of resource
+# TYPE example_server3 gauge
+example_server3{id="n-181<redacted>",name="example_server3",tags="{'alert': ''}",task="health_check"} 0.0
+```
+
+# Scraping the metrics with Prometheus
+
+Adding the following job to the `prometheus.yml` file will scrape the metrics from our new endpoint (replace `localhost` with the appropriate IP or hostname):
+
+```
+  - job_name: "sdm_health_exporter"
+    static_configs:
+      - targets: ["localhost:8337"]
+```
+
+
+# Alerting on failures
+
+If you use Alert Manager with Prometheus, you can use a PromQL expression similar to the one below to alert on unhealthy resources/nodes:
+
+`{job="sdm_health_exporter", task="health_check"} == 1`

--- a/monitoring/sdm_health_exporter/requirements.txt
+++ b/monitoring/sdm_health_exporter/requirements.txt
@@ -1,0 +1,8 @@
+googleapis-common-protos==1.52.0
+grpcio==1.42.0
+prometheus-client==0.13.1
+protobuf==3.19.4
+pydantic==1.9.0
+six==1.16.0
+strongdm==1.0.35
+typing-extensions==4.1.0

--- a/monitoring/sdm_health_exporter/sdm_health_exporter.py
+++ b/monitoring/sdm_health_exporter/sdm_health_exporter.py
@@ -1,0 +1,178 @@
+import os
+import time
+from typing import Any
+from pydantic import BaseModel
+import strongdm
+from prometheus_client import start_http_server, Gauge
+
+"""
+sdm_exporter.py
+
+This script serves as an example exporter that can monitor the
+health of resources ("Infrastructure") and nodes ("Gateways/Relays").
+
+The script uses the following workflow:
+
+- Make an API call to strongDM's API to retrive information about resources
+and nodes. The frequency of the API call is configurable by updating the
+"update_interval" variable in "main()"
+
+- Collect data about any resource or node that is tagged with "alert" in strongDM.
+This tag is configurable by updating the "alert_tag" variable in "main()"
+
+- Export metrics to a prometheus endpoint as a gauge (0 for healthy, 1 for unhealthy)
+"""
+
+class SdmObject(BaseModel):   
+    """
+    Pydantic class with type enforcement
+    Prometheus object of type "Gauge"
+    Possible values: healthy: 0, unhealthy: 1
+    """
+    health_metric: Gauge
+
+    class Config:
+        validate_assignment = True
+        arbitrary_types_allowed = True
+
+
+def strip_invalid_chars(name):
+    """
+    Dashes are invalid for prometheus metric but allowed in strongDM
+    """
+    return name.replace('-','_')
+
+
+def get_sdm_keys():
+    """
+    Loads API keys from environment variables.
+    Raises: KeyError if environment variables are not found
+    Returns: strings for API ID and secret
+    """
+
+    try:
+        api_id = os.environ['SDM_API_ID']
+        api_secret = os.environ['SDM_API_SECRET']
+    except KeyError as ke:
+        print(f'FATAL: Missing env variable: {ke}. Exiting...')
+        exit()
+
+    return api_id, api_secret
+
+
+def get_sdm_resources(client, alert_tag, sdm_objects):
+    """
+    Issue strongDM API calls every <update_interval> to collect information on resources
+    Export any resource that's tagged with <alert_tag> in strongDM to a prometheus exporter
+    Returns: dictionary of SdmObject instances, keyed by resource name
+    """
+
+    # prometheus labels that will be attached to the exported metric
+    labels = ['id','name','tags','task']
+
+    for resource in client.resources.list(''):
+        
+        # make sure there are no characters that are invalid for the prometheus exporter
+        resource_name = strip_invalid_chars(resource.name)
+
+        # only process resources that are tagged with <alert_tag> in strongDM
+        if alert_tag not in resource.tags:
+            continue
+
+        # only register a new prometheus collector if it's not an existing object
+        # create a new "Gauge" and define the labels that will be used for the metric
+        # create new SdmObject with this information and add it to "sdm_objects" dictionary
+        if resource_name not in sdm_objects:
+            health_metric = Gauge(resource_name, 'health of resource', labelnames=labels)
+            sdm_objects[resource_name] = SdmObject(health_metric=health_metric)
+
+        # resource health is returned as True or False
+        # set the label values based on information retrieved from the API call
+        # set the metric to 0 (healthy) or 1 (unhealthy)
+        sdm_objects[resource_name].health_metric.labels(
+            id=resource.id,
+            name=resource_name,                       
+            tags=resource.tags,
+            task='health_check'
+        ).set(0 if resource.healthy else 1)
+
+    return sdm_objects
+
+
+def get_sdm_nodes(client, alert_tag, sdm_objects):
+    """
+    Issue strongDM API calls every <update_interval> to collect information on nodes
+    Export any resource that's tagged with <alert_tag> in strongDM to a prometheus exporter
+    Returns: dictionary of SdmObject instances, keyed by node name
+    """
+
+    # prometheus labels that will be attached to the exported metric
+    labels = ['id','name','tags','task']
+
+    for node in client.nodes.list(''):
+        
+        # make sure there are no characters that are invalid for the prometheus exporter
+        node_name = strip_invalid_chars(node.name)
+
+        # only process nodes that are tagged with <alert_tag> in strongDM
+        if alert_tag not in node.tags:
+            continue
+
+        # only register a new prometheus collector if it's not an existing object
+        # create a new "Gauge" and define the labels that will be used for the metric
+        # create new SdmObject with this information and add it to "sdm_objects" dictionary
+        if node_name not in sdm_objects:
+            health_metric = Gauge(node_name, 'health of resource', labelnames=labels)
+            sdm_objects[node_name] = SdmObject(health_metric=health_metric)
+
+        # node health is returned as "started" or "stopped"
+        # make sure that the "state" value we received is expected
+        if node.state not in ("started", "stopped"):
+            raise ValueError(f'Received unexpected state: {node.state}')
+
+        # set the label values based on information retrieved from the API call
+        # set the metric to 0 (healthy) or 1 (unhealthy)
+        sdm_objects[node_name].health_metric.labels(
+            id=node.id,
+            name=node_name,
+            tags=node.tags,
+            task='health_check'
+        ).set(0 if node.state == "started" else 1)
+
+    return sdm_objects
+
+
+def main():
+
+    # frequency to issue API call to strongDM
+    update_interval = 60
+
+    # filter strongDM results to resources that are tagged with <alert_tag> in strongDM
+    alert_tag = 'alert'
+
+    # retrieve strongDM API keys
+    api_id, api_secret = get_sdm_keys()
+
+    # keeps track of SdmObject instances, keyed by resource name
+    sdm_objects = {}
+
+    # start prometheus endpoint
+    start_http_server(8337) 
+
+    # strongDM API client
+    client = strongdm.Client(api_id, api_secret)
+
+    # issue API calls to obtain health status indefinitely with a frequency of <update_interval>
+    while True:    
+    
+        # collect resources and objects and write them out to a Prometheus exporter
+        # returns dictionary of SdmObject instances, keyed by resource or node name 
+        sdm_objects = get_sdm_resources(client, alert_tag, sdm_objects)
+        sdm_objects = get_sdm_nodes(client, alert_tag, sdm_objects)
+        
+        # wait "update_interval" amount of time before issuing the next API call
+        time.sleep(update_interval)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This script serves as an example exporter that can monitor the
health of resources ("Infrastructure") and nodes ("Gateways/Relays").

The script uses the following workflow:

- Make an API call to strongDM's API to retrive information about resources and
nodes. The frequency of the API call is configurable by updating the "update_interval"
variable in "main()"

- Collect data about any resource or node that is tagged with <alert_tag> in strongDM.
This tag is configurable by updating the "alert_tag" variable in "main()"

- Export metrics to a prometheus endpoint as a "Gauge" (0 for healthy, 1 for unhealthy)