### PR TITLE
Added a permission for running role_resources.py

### DIFF
--- a/audit/roles/README.md
+++ b/audit/roles/README.md
@@ -7,6 +7,7 @@ This folder contains a Python script that lists all Roles and the Resources link
 * A [strongDM API key pair](https://www.strongdm.com/docs/admin-ui-guide/settings/admin-tokens/api-keys) with the following permissions:
   * Roles: List
   * Datasources: List
+  * Grants: Read
 
 ## Usage
 * Run `pip install strongdm`


### PR DESCRIPTION
Without Grants/Read permission, I get the following error when running role_resources.py.
Tested with the Grants Read permission and it now works.  
Adding to the readme file 

% python role_resources.py
~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=
Role name: "non-prod-mongo-rw" includes the following resources:
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/strongdm/svc.py", line 1163, in generator
    plumbing_response = svc.stub.List(
  File "/usr/local/lib/python3.9/site-packages/grpc/_channel.py", line 946, in __call__
    return _end_unary_response_blocking(state, call, False, None)
  File "/usr/local/lib/python3.9/site-packages/grpc/_channel.py", line 849, in _end_unary_response_blocking
    raise _InactiveRpcError(state)
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.PERMISSION_DENIED
	details = "permission denied: access denied"
	debug_error_string = "{"created":"@1647181583.638492000","description":"Error received from peer ipv4:99.83.168.70:443","file":"src/core/lib/surface/call.cc","file_line":1064,"grpc_message":"permission denied: access denied","grpc_status":7}"
>